### PR TITLE
Link to READMEs?

### DIFF
--- a/Catalogue/datasets/datasets-intro.md
+++ b/Catalogue/datasets/datasets-intro.md
@@ -4,10 +4,10 @@ These are the currently available datasets.
 
 **Index**
 
-* [CMAP](cmap.md)			
-* [](cmip6_etccdi.md)		
-* [](cmorph.md)		
-* [](frogs.md)
-* [](ghcn.md)
-* [GPCC](gpcc.md)
-* [](gpcp.md)
+* [CMAP](https://github.com/aus-ref-clim-data-nci/CMAP#readme)			
+* [CMIP6-ETCCDI](https://github.com/aus-ref-clim-data-nci/CMIP6_ETCCDI#readme)		
+* [CMORPH](https://github.com/aus-ref-clim-data-nci/CMORPH#readme)		
+* [FROGS](https://github.com/aus-ref-clim-data-nci/FROGS#readme)
+* [GHCN](https://github.com/aus-ref-clim-data-nci/GHCN#readme)
+* [GPCC](https://github.com/aus-ref-clim-data-nci/GPCC#readme)
+* [GPCP](https://github.com/aus-ref-clim-data-nci/GPCP#readme)


### PR DESCRIPTION
I wonder whether the hyperlinks at https://aus-ref-clim-data-nci.github.io/aus-ref-clim-data-nci/datasets/datasets-intro.html should link to the README in the relevant repo, rather than us having to duplicate READMEs by having a copy at https://github.com/aus-ref-clim-data-nci/aus-ref-clim-data-nci/tree/book/Catalogue/datasets?