### PR TITLE
Fix deploy workflow Python runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
+        os: [ubuntu-22.04]
+        python-version: ["3.8"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Install dependencies
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Closes #17.

Summary:
- Pin the deploy job to ubuntu-22.04 so the existing Python 3.8 based Jupyter Book stack can continue to run.
- Update actions/checkout and actions/setup-python to current major versions.
- Quote the Python matrix value so it is handled consistently as a version string.

Verification:
- Inspected failing deploy run 26208614402. The job currently fails before dependency installation with: Version 3.8 with arch x64 not found.
- Not run locally: my local environment only has Python 3.14, which is too new for this repository's pinned Jupyter Book 0.11 dependency stack.