### PR TITLE
Pin pybtex for Jupyter Book build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 numpy
 ghp-import
 jinja2==3.0.0
+pybtex<0.25


### PR DESCRIPTION
Follow-up to #18.

Summary:
- Add an explicit pybtex less-than 0.25 constraint for the existing Jupyter Book 0.11 dependency stack.

Why:
- The deploy workflow now reaches the Jupyter Book build after #18.
- The latest failing run stops while importing sphinxcontrib.bibtex: cannot import name _FakeEntryPoint from pybtex.plugin.
- This keeps the older Jupyter Book/Sphinx stack intact while avoiding the incompatible newer pybtex release.

Verification:
- Inspected failing deploy run 26429301456 / job 77799039711.
- Not run locally: my local environment only has Python 3.14, while this repository is intentionally building with Python 3.8.